### PR TITLE
mistake in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ Add the repository to the root's build.gradle.
 
 ```groovy
 allprojects {
- repositories {
-    jcenter()
-    maven { url "https://jitpack.io" }
- }
+        repositories {
+            jcenter()
+            maven { url "https://jitpack.io" }
+        }
+    }
 ```
 
 And add dependencies to the module's build.gradle.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -44,10 +44,11 @@ jlog是一款针对Android开发者的日志工具。
 
 ```groovy
 allprojects {
- repositories {
-    jcenter()
-    maven { url "https://jitpack.io" }
- }
+        repositories {
+            jcenter()
+            maven { url "https://jitpack.io" }
+        }
+    }
 ```
 
 在模块的build.gradle中添加依赖。


### PR DESCRIPTION
> allprojects {
>         repositories {
>             jcenter()
>             maven { url "https://jitpack.io" }
>         }
missing “}”